### PR TITLE
EDIVORCE-45 - Update configurations and documentation

### DIFF
--- a/openshift/edivorce-django-deploy.prod.param
+++ b/openshift/edivorce-django-deploy.prod.param
@@ -11,8 +11,8 @@
 # #DJANGO_SECRET_KEY=[\w]{50}
 # IMAGE_NAMESPACE=jag-csb-edivorce-tools
 TAG_NAME=prod
-# PROXY_URL_PREFIX=/divorce
-# PROXY_BASE_URL=https://justice.gov.bc.ca
+PROXY_URL_PREFIX=/divorce
+PROXY_BASE_URL=https://justice.gov.bc.ca
 BASICAUTH_ENABLED=False
 # BASICAUTH_USERNAME=divorce
 # BASICAUTH_PASSWORD=[a-zA-Z0-9]{16}

--- a/openshift/edivorce-django-deploy.test.param
+++ b/openshift/edivorce-django-deploy.test.param
@@ -11,8 +11,8 @@
 # #DJANGO_SECRET_KEY=[\w]{50}
 # IMAGE_NAMESPACE=jag-csb-edivorce-tools
 TAG_NAME=test
-# PROXY_URL_PREFIX=/divorce
-# PROXY_BASE_URL=https://test.justice.gov.bc.ca
+PROXY_URL_PREFIX=/divorce
+PROXY_BASE_URL=https://test.justice.gov.bc.ca
 BASICAUTH_ENABLED=True
 # BASICAUTH_USERNAME=divorce
 # BASICAUTH_PASSWORD=[a-zA-Z0-9]{16}

--- a/openshift/nginx-proxy-deploy.dev.param
+++ b/openshift/nginx-proxy-deploy.dev.param
@@ -6,6 +6,5 @@
 # NAME=nginx-proxy
 # IMAGE_NAMESPACE=jag-csb-edivorce-tools
 TAG_NAME=dev
-APPLICATION_DOMAIN=edivorce-dev.pathfinder.gov.bc.ca
 SITEMINDER_APPLICATION_DOMAIN=edivorce-dev.pathfinder.bcgov
 # SITEMINDER_WHITE_LIST=

--- a/openshift/nginx-proxy-deploy.param
+++ b/openshift/nginx-proxy-deploy.param
@@ -6,6 +6,5 @@
 NAME=nginx-proxy
 IMAGE_NAMESPACE=jag-csb-edivorce-tools
 TAG_NAME=dev
-APPLICATION_DOMAIN=edivorce-dev.pathfinder.gov.bc.ca
 SITEMINDER_APPLICATION_DOMAIN=edivorce-dev.pathfinder.bcgov
 SITEMINDER_WHITE_LIST=

--- a/openshift/nginx-proxy-deploy.prod.param
+++ b/openshift/nginx-proxy-deploy.prod.param
@@ -6,6 +6,5 @@
 # NAME=nginx-proxy
 # IMAGE_NAMESPACE=jag-csb-edivorce-tools
 TAG_NAME=prod
-APPLICATION_DOMAIN=edivorce-prod.pathfinder.gov.bc.ca
 SITEMINDER_APPLICATION_DOMAIN=edivorce-prod.pathfinder.bcgov
 # SITEMINDER_WHITE_LIST=

--- a/openshift/nginx-proxy-deploy.test.param
+++ b/openshift/nginx-proxy-deploy.test.param
@@ -6,6 +6,5 @@
 # NAME=nginx-proxy
 # IMAGE_NAMESPACE=jag-csb-edivorce-tools
 TAG_NAME=test
-APPLICATION_DOMAIN=edivorce-test.pathfinder.gov.bc.ca
 SITEMINDER_APPLICATION_DOMAIN=edivorce-test.pathfinder.bcgov
 # SITEMINDER_WHITE_LIST=

--- a/openshift/templates/nginx-proxy/nginx-proxy-deploy.yaml
+++ b/openshift/templates/nginx-proxy/nginx-proxy-deploy.yaml
@@ -86,26 +86,6 @@ objects:
 - kind: Route
   apiVersion: v1
   metadata:
-    name: "${NAME}"
-    creationTimestamp:
-    labels:
-      app: "${NAME}"
-    annotations:
-      openshift.io/host.generated: 'true'
-  spec:
-    host: "${APPLICATION_DOMAIN}"
-    to:
-      kind: Service
-      name: "${NAME}"
-      weight: 100
-    port:
-      targetPort: 8080-tcp
-    tls:
-      termination: edge
-      insecureEdgeTerminationPolicy: Redirect
-- kind: Route
-  apiVersion: v1
-  metadata:
     name: "${NAME}-siteminder-route"
     labels:
       app: "${NAME}-siteminder-route"
@@ -147,11 +127,6 @@ parameters:
   description: The TAG name for this environment, e.g., dev, test, prod.
   required: true
   value: "dev"
-- name: APPLICATION_DOMAIN
-  displayName: Application Hostname
-  description: The exposed hostname that will route to the Django service, if left blank a value will be defaulted.
-  required: true
-  value: "edivorce-dev.pathfinder.gov.bc.ca"
 - name: SITEMINDER_APPLICATION_DOMAIN
   displayName: SiteMinder Application Domain
   description: The endpoint used for SiteMinder routed access to the application.


### PR DESCRIPTION
- All of the RP and SiteMinder changes have been implemented.  Update the configurations and documentation to reflect the changes.
  - Remove the public route from the nginx configuration template, it is no longer used.