### PR TITLE
Fixed missing other orders from Form 52

### DIFF
--- a/edivorce/apps/core/templates/pdf/form52.html
+++ b/edivorce/apps/core/templates/pdf/form52.html
@@ -142,8 +142,8 @@
                 </li>
         {% endif %}
 
-        {% if responses.other_orders_detail.trim %}
-                <li>{{ responses.other_orders_detail }}</li>
+        {% if responses.other_orders_detail.strip %}
+                {{ responses.other_orders_detail|striptags|linebreaksli }}
         {% endif %}
     {% endif %}
             </ol>


### PR DESCRIPTION
Changed from trim() to strip() and added template tags to sanitize the output.
Tested with multiple entries and whitespace.