### PR TITLE
DEV-968: Remove ", British Columbia" from notary signature

### DIFF
--- a/edivorce/apps/core/templates/pdf/partials/notary_signature.html
+++ b/edivorce/apps/core/templates/pdf/partials/notary_signature.html
@@ -6,7 +6,7 @@
       <td class=""> </td>
     </tr>
     <tr>
-      <td class="">at <span class="form-entry not-complete">&nbsp;</span>, British Columbia</td>
+      <td class="">at <span class="form-entry not-complete">&nbsp;</span></td>
       <td class="parens"> ) </td>
       <td class=""></td>
     </tr>


### PR DESCRIPTION
Removes it from Form 37 and Form 38, as Kevin requested.