### PR TITLE
Updated form dates to "dd/mmm/yyyy"

### DIFF
--- a/edivorce/apps/core/templates/pdf/form1.html
+++ b/edivorce/apps/core/templates/pdf/form1.html
@@ -61,7 +61,7 @@
                     <td>
                       <span class="td-list-item">{% checkbox responses.when_were_you_live_married_like %}</span>
                       began to live together in a marriage-like relationship on
-                      <em class="no-wrap">[dd mmm yyyy]</em>
+                      <em class="no-wrap">[dd/mmm/yyyy]</em>
                     </td>
                     <td colname="c2">
                       {% response responses.when_were_you_live_married_like as_date=True %}
@@ -70,7 +70,7 @@
                 <tr>
                     <td>
                       <span class="td-list-item">{% checkbox responses.when_were_you_married %}</span>
-                      were married on <em class="no-wrap">[dd mmm yyyy]</em>
+                      were married on <em class="no-wrap">[dd/mmm/yyyy]</em>
                     </td>
                     <td colname="c2">
                       {% response responses.when_were_you_married as_date=True %}
@@ -79,7 +79,7 @@
                 <tr>
                     <td>
                       <span class="td-list-item">{% checkbox responses.separation_date %}</span>
-                      separated on <em class="no-wrap">[dd mmm yyyy]</em>
+                      separated on <em class="no-wrap">[dd/mmm/yyyy]</em>
                     </td>
                     <td colname="c2">
                       {% response responses.separation_date as_date=True %}
@@ -89,7 +89,7 @@
                     <td>
                       <span class="td-list-item">{% checkbox False %}</span>
                       were divorced from each other by order made on
-                      <em class="no-wrap">[dd mmm yyyy]</em>
+                      <em class="no-wrap">[dd/mmm/yyyy]</em>
                     </td>
                     <td colname="c2"><span class="form-entry not-complete">&nbsp;</span></td>
                 </tr>
@@ -125,14 +125,14 @@
                     <td colname="c3"><strong>Claimant 2</strong></td>
                 </tr>
                 <tr>
-                    <td>Birthdate: <em class="no-wrap">[dd mmm yyyy]</em></td>
+                    <td>Birthdate: <em class="no-wrap">[dd/mmm/yyyy]</em></td>
                     <td colname="c2">{% response responses.birthday_you as_date=True %}</td>
                     <td colname="c3">{% response responses.birthday_spouse as_date=True %}</td>
                 </tr>
                 <tr>
                     <td>
                       Ordinarily resident in British Columbia since:
-                      <em class="no-wrap">[dd mmm yyyy]</em>
+                      <em class="no-wrap">[dd/mmm/yyyy]</em>
                     </td>
                     <td colname="c2">
                       {% if responses.lived_in_bc_you == 'Since birth' %}
@@ -207,7 +207,7 @@
                     <td colspan="2">
                       <span class="td-list-item">(i) {% checkbox responses.separation_date %}</span>
                       Claimant 1 and Claimant 2 have lived separate and apart
-                      since {% response responses.separation_date %}
+                      since {% response responses.separation_date|date_formatter %}
                     </td>
                 </tr>
                 <tr>
@@ -383,7 +383,7 @@
                           <table class="table table-fixed table-bordered">
                               <tr>
                                   <th align="center">Full name</th>
-                                  <th align="center">Birth date<br />[<em>dd mmm yyyy</em>]</th>
+                                  <th align="center">Birth date<br />[<em>dd/mmm/yyyy</em>]</th>
                                   <th align="center">Resides with</th>
                               </tr
       {% if responses.children_of_marriage == 'YES' %}
@@ -718,7 +718,7 @@
                 </tr>
                 <tr>
                     <td class="sig-col1"></td>
-                    <td class="sig-col2 sig-line-text">[dd mmm yyyy]</td>
+                    <td class="sig-col2 sig-line-text">[dd/mmm/yyyy]</td>
                     <td class="sig-col3"></td>
                     <td class="sig-col4 sig-line-text">
                         <p>
@@ -743,7 +743,7 @@
                 </tr>
                 <tr>
                     <td class="sig-col1"></td>
-                    <td class="sig-col2 sig-line-text">[dd mmm yyyy]</td>
+                    <td class="sig-col2 sig-line-text">[dd/mmm/yyyy]</td>
                     <td class="sig-col3"></td>
                     <td class="sig-col4 sig-line-text">
                         <p>
@@ -786,7 +786,7 @@
                 </tr>
                 <tr>
                     <td class="sig-col1"></td>
-                    <td class="sig-col2 sig-line-text">[dd mmm yyyy]</td>
+                    <td class="sig-col2 sig-line-text">[dd/mmm/yyyy]</td>
                     <td class="sig-col3"></td>
                     <td class="sig-col4 sig-line-text">
                         <p>
@@ -834,7 +834,7 @@
                 </tr>
                 <tr>
                     <td class="sig-col1"></td>
-                    <td class="sig-col2 sig-line-text">[dd mmm yyyy]</td>
+                    <td class="sig-col2 sig-line-text">[dd/mmm/yyyy]</td>
                     <td class="sig-col3"></td>
                     <td class="sig-col4 sig-line-text">
                         <p>

--- a/edivorce/apps/core/templates/pdf/form37.html
+++ b/edivorce/apps/core/templates/pdf/form37.html
@@ -165,7 +165,7 @@
   {% for child in responses.children %}
                   <tr>
                     <td>{{ child.child_name }}</td>
-                    <td>{{ child.child_birth_date|date_formatter }} &nbsp;</td>
+                    <td style="white-space: nowrap">{{ child.child_birth_date|date_formatter }} &nbsp;</td>
                     <td>{{ child.child_birth_date|age }}</td>
                     <td>{{ child.child_live_with|claimantize }}</td>
                     <td>{{ child.child_relationship_to_you }}</td>

--- a/edivorce/apps/core/templates/pdf/form52.html
+++ b/edivorce/apps/core/templates/pdf/form52.html
@@ -82,8 +82,8 @@
                 {% else %}<span class="form-entry not-complete"></span>{% endif %}
                 on
                 {% if responses.when_were_you_married %}
-                    {{ responses.when_were_you_married|date_formatter }}
-                {% else %}<span class="form-entry not-complete"></span>{% endif %},
+                    {{ responses.when_were_you_married|date_formatter }},
+                {% else %}<span class="form-entry not-complete"></span>,{% endif %}
                 are divorced from each other, the divorce to take effect on
                 {% effective_date %}.
             </p>

--- a/edivorce/apps/core/templatetags/format_utils.py
+++ b/edivorce/apps/core/templatetags/format_utils.py
@@ -26,7 +26,7 @@ def linebreaksli(value):
 
 @register.filter
 def date_formatter(value):
-    """ Changes date format from dd/mm/yyyy to dd mmm yyyy """
+    """ Changes date format to dd/mmm/yyyy """
 
     if value is None or value == '':
         return ''
@@ -39,7 +39,7 @@ def date_formatter(value):
     if date is None:
         date = datetime.strptime(value, '%b %d, %Y')
 
-    return date.strftime('%d %b %Y')
+    return date.strftime('%d/%b/%Y')
 
 
 @register.simple_tag()


### PR DESCRIPTION
As requested in DIV-966: According to the Supreme Court Family Rules, the format of dates on output forms should be "dd/mmm/yyyy". e.g. "16/Nov/2019"

Ensured the date doesn't get wrapped in the table in Form 37 

Also fixed a small formatting error where a date has a space before a comma