### PR TITLE
Added check for child support in Form35

### DIFF
--- a/edivorce/apps/core/templates/pdf/form35.html
+++ b/edivorce/apps/core/templates/pdf/form35.html
@@ -85,11 +85,11 @@
             {% checkbox True %} proof of service of the notice of family claim or counterclaim, as the case may be.
           </p>
           <p>
-            {% if responses.num_actual_children > 0 %}
-              {% checkbox True %} 
+            {% if responses.num_actual_children > 0 and 'Child support' in responses.want_which_orders %}
+                {% checkbox True %}
             {% else %}
               {% checkbox False %}
-            {% endif %} 
+            {% endif %}
             Child Support Affidavit in Form F37.
           </p>
           <p>


### PR DESCRIPTION
Kevin requested that the `Child Support Affidavit in Form F37` checkbox in Form 35 also only show up if the `Orders pertaining to children` was checked in `STEP 1: What are you asking for`.

I put the additional logic in the template, which I'm not sure is good practice, but I felt it might be ok in this case. If you think there should be a separate variable created for this, or a function, let me know (or point me to an example implementation).