### PR TITLE
Unchecked in Form 35

### DIFF
--- a/edivorce/apps/core/templates/pdf/form35.html
+++ b/edivorce/apps/core/templates/pdf/form35.html
@@ -82,7 +82,7 @@
             {% checkbox True %} filing fee.
           </p>
           <p>
-            {% checkbox True %} proof of service of the notice of family claim or counterclaim, as the case may be.
+            {% checkbox False %} proof of service of the notice of family claim or counterclaim, as the case may be.
           </p>
           <p>
             {% if responses.num_actual_children > 0 and 'Child support' in responses.want_which_orders %}


### PR DESCRIPTION
Request from Kevin Conn that "proof of service of the notice of family claim or counterclaim, as the case may be" should always be unchecked in Form 35.