### PR TITLE
DIV-1246 - Change the implementation of efiling JWT tokens, so we don…

### DIFF
--- a/edivorce/apps/core/tests/test_efiling_submission.py
+++ b/edivorce/apps/core/tests/test_efiling_submission.py
@@ -47,7 +47,7 @@ class EFilingSubmissionTests(TransactionTestCase):
         middleware = SessionMiddleware()
         middleware.process_request(self.request)
         self.request.session.save()
-        
+
         self.hub = EFilingSubmission(initial_filing=True)
         self.packaging = EFilingPackaging(initial_filing=True)
 
@@ -70,8 +70,7 @@ class EFilingSubmissionTests(TransactionTestCase):
             text=json.dumps(SAMPLE_TOKEN_RESPONSE))
 
         self.assertTrue(self.hub._get_token(self.request))
-        self.assertEqual(self.request.session['access_token'],
-                         SAMPLE_TOKEN_RESPONSE['access_token'])
+        self.assertEqual(self.hub.access_token, SAMPLE_TOKEN_RESPONSE['access_token'])
 
     @mock.patch('requests.post')
     def test_get_token_error(self, mock_request_post):
@@ -85,11 +84,10 @@ class EFilingSubmissionTests(TransactionTestCase):
     def test_renew_token(self, mock_request_post):
         mock_request_post.return_value = self._mock_response(
             text=json.dumps(SAMPLE_TOKEN_RESPONSE))
-        self.request.session['refresh_token'] = 'alskdfjadlfads'
+        self.hub.refresh_token = 'alskdfjadlfads'
 
         self.assertTrue(self.hub._refresh_token(self.request))
-        self.assertEqual(self.request.session['access_token'],
-                         SAMPLE_TOKEN_RESPONSE['access_token'])
+        self.assertEqual(self.hub.access_token, SAMPLE_TOKEN_RESPONSE['access_token'])
 
     @mock.patch('requests.post')
     def test_renew_token_anon(self, mock_request_post):
@@ -104,17 +102,16 @@ class EFilingSubmissionTests(TransactionTestCase):
     def test_renew_token_error(self, mock_request_post):
         mock_request_post.return_value = self._mock_response(
             text=json.dumps(SAMPLE_TOKEN_RESPONSE), status=401)
-        self.request.session['refresh_token'] = 'alskdfjadlfads'
+        self.hub.refresh_token = 'alskdfjadlfads'
 
         self.assertTrue(self.hub._refresh_token(self.request))
-        self.assertEqual(self.request.session['access_token'],
-                         SAMPLE_TOKEN_RESPONSE['access_token'])
+        self.assertEqual(self.hub.access_token, SAMPLE_TOKEN_RESPONSE['access_token'])
 
     @mock.patch('requests.post')
     def test_get_api_success(self, mock_request_post):
         mock_request_post.return_value = self._mock_response(
             text=json.dumps(INITIAL_DOC_UPLOAD_RESPONSE))
-        self.request.session['access_token'] = 'aslkfjadskfjd'
+        self.hub.access_token = 'aslkfjadskfjd'
 
         response = self.hub._get_api(
             self.request, 'https://somewhere.com', 'alksdjfa', 'kasdkfd', {})
@@ -126,8 +123,8 @@ class EFilingSubmissionTests(TransactionTestCase):
 
     @mock.patch('requests.post')
     def test_get_api_expired_token(self, mock_request_post):
-        self.request.session['access_token'] = 'aslkfjadskfjd'
-        self.request.session['refresh_token'] = 'alskdfjadlfads'
+        self.hub.access_token = 'aslkfjadskfjd'
+        self.hub.refresh_token = 'alskdfjadlfads'
 
         # we want 3 mock side effects for post .. a 401 on the first and success on token renewal
         mock_request_post.side_effect = [

--- a/edivorce/apps/core/utils/efiling_submission.py
+++ b/edivorce/apps/core/utils/efiling_submission.py
@@ -19,10 +19,11 @@ class EFilingSubmission:
         self.token_base_url = settings.EFILING_HUB_KEYCLOAK_BASE_URL
         self.token_realm = settings.EFILING_HUB_KEYCLOAK_REALM
         self.api_base_url = settings.EFILING_HUB_API_BASE_URL
-
-        self.submission_id = None
         self.initial_filing = initial_filing
         self.packaging = EFilingPackaging(initial_filing)
+        self.submission_id = None
+        self.access_token = None
+        self.refresh_token = None
 
     def _get_token(self, request):
         payload = f'client_id={self.client_id}&grant_type=client_credentials&client_secret={self.client_secret}'
@@ -35,21 +36,20 @@ class EFilingSubmission:
         if response.status_code == 200:
             response = json.loads(response.text)
 
-            # save in session .. lets just assume that current user is authenticated
+            # save token as object property..
             if 'access_token' in response:
-                request.session['access_token'] = response['access_token']
+                self.access_token = response['access_token']
                 if 'refresh_token' in response:
-                    request.session['refresh_token'] = response['refresh_token']
+                    self.refresh_token = response['refresh_token']
 
                 return True
         return False
 
     def _refresh_token(self, request):
-        refresh_token = request.session.get('refresh_token', None)
-        if not refresh_token:
+        if not self.refresh_token:
             return False
 
-        payload = f'client_id={self.client_id}&grant_type=refresh_token&client_secret={self.client_secret}&refresh_token={refresh_token}'
+        payload = f'client_id={self.client_id}&grant_type=refresh_token&client_secret={self.client_secret}&refresh_token={self.refresh_token}'
         headers = {'Content-Type': 'application/x-www-form-urlencoded'}
 
         url = f'{self.token_base_url}/auth/realms/{self.token_realm}/protocol/openid-connect/token'
@@ -61,25 +61,23 @@ class EFilingSubmission:
 
         # save in session .. lets just assume that current user is authenticated
         if 'access_token' in response:
-            request.session['access_token'] = response['access_token']
+            self.access_token = response['access_token']
             if 'refresh_token' in response:
-                request.session['refresh_token'] = response['refresh_token']
+                self.refresh_token = response['refresh_token']
 
             return True
         return False
 
     def _get_api(self, request, url, transaction_id, bce_id, headers, data=None, files=None):
-        # make sure we have a session
-        access_token = request.session.get('access_token', None)
-        if not access_token:
+        # make sure we have an access token
+        if not self.access_token:
             if not self._get_token(request):
                 raise Exception('EFH - Unable to get API Token')
 
-        access_token = request.session.get('access_token', None)
         headers.update({
             'X-Transaction-Id': transaction_id,
             'X-User-Id': bce_id,
-            'Authorization': f'Bearer {access_token}'
+            'Authorization': f'Bearer {self.access_token}'
         })
 
         if not data:
@@ -91,11 +89,10 @@ class EFilingSubmission:
         if response.status_code == 401:
             # not authorized .. try refreshing token
             if self._refresh_token(request):
-                access_token = request.session.get('access_token', None)
                 headers.update({
                     'X-Transaction-Id': transaction_id,
                     'X-User-Id': bce_id,
-                    'Authorization': f'Bearer {access_token}'
+                    'Authorization': f'Bearer {self.access_token}'
                 })
 
                 response = requests.post(url, headers=headers, data=data, files=files)
@@ -173,7 +170,7 @@ class EFilingSubmission:
 
                 response = json.loads(response.text)
 
-                if response['details'] and len(response['details']) > 0:
+                if 'details' in response and len(response['details']) > 0:
                     return None, response['details'][0]
 
                 return None, f"{response['error']} - {response['message']}"


### PR DESCRIPTION
When the POC was developed, single-sign-on was not possible because eDivorce was using SiteMinder and the EFiling Hub was using KeyCloak.  Now that both applications are in the same Keycloak realm, there is no reason to store credentials.