### PR TITLE
Suggestion: Support for users with duplicate emails.

### DIFF
--- a/edivorce/apps/core/middleware/keycloak.py
+++ b/edivorce/apps/core/middleware/keycloak.py
@@ -1,7 +1,7 @@
 import base64
 import hashlib
 from django.conf import settings
-from django.utils.encoding import force_bytes, smart_text, smart_bytes
+from django.utils.encoding import force_bytes
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 from mozilla_django_oidc.utils import absolutify
 

--- a/edivorce/apps/core/middleware/keycloak.py
+++ b/edivorce/apps/core/middleware/keycloak.py
@@ -1,7 +1,7 @@
 import base64
 import hashlib
 from django.conf import settings
-from django.utils.encoding import force_bytes
+from django.utils.encoding import force_bytes, smart_text
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 from mozilla_django_oidc.utils import absolutify
 
@@ -17,9 +17,9 @@ class EDivorceKeycloakBackend(OIDCAuthenticationBackend):
     def create_user(self, claims):
         email = claims.get('email')
         universal_id = claims.get('universal-id')
-        username = base64.urlsafe_b64encode(
+        username = smart_text(base64.urlsafe_b64encode(
         hashlib.sha1(force_bytes(universal_id)).digest()
-            ).rstrip(b'=')
+            ).rstrip(b'='))
 
         user = self.UserModel.objects.create_user(username, email=email)
         user.first_name = claims.get('given_name', '')

--- a/edivorce/apps/core/middleware/keycloak.py
+++ b/edivorce/apps/core/middleware/keycloak.py
@@ -1,4 +1,7 @@
+import base64
+import hashlib
 from django.conf import settings
+from django.utils.encoding import force_bytes, smart_text, smart_bytes
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 from mozilla_django_oidc.utils import absolutify
 
@@ -12,8 +15,13 @@ class EDivorceKeycloakBackend(OIDCAuthenticationBackend):
         return verified
 
     def create_user(self, claims):
-        user = super(EDivorceKeycloakBackend, self).create_user(claims)
+        email = claims.get('email')
+        universal_id = claims.get('universal-id')
+        username = base64.urlsafe_b64encode(
+        hashlib.sha1(force_bytes(universal_id)).digest()
+            ).rstrip(b'=')
 
+        user = self.UserModel.objects.create_user(username, email=email)
         user.first_name = claims.get('given_name', '')
         user.last_name = claims.get('family_name', '')
         user.display_name = "{} {}".format(user.first_name, user.last_name).strip()


### PR DESCRIPTION
**Note: I haven't tested this code. It would have to be tested to ensure there are no leaks / bugs.** 

This file I believe inherits from here:
https://github.com/mozilla/mozilla-django-oidc/blob/master/mozilla_django_oidc/auth.py

I think this might solve the duplicate email user issue, because it's keying users on a hashed email. This should override it to use universal-id as a username key instead. I don't think it should impact the existing users because filter_users_by_claims is looking up by universal-id and not by email. filter_users_by_claims is called before create_user it seems. Still would need to be tested. 
