### PR TITLE
Update all links to family.legalaidbc.bc.ca

### DIFF
--- a/edivorce/apps/core/templates/dashboard/print_form.html
+++ b/edivorce/apps/core/templates/dashboard/print_form.html
@@ -195,7 +195,7 @@
                 </p>
                 <ul>
                     <li>
-                        <a href="https://familylaw.lss.bc.ca/resources/fact_sheets/tipsForDraftingOrders.php"
+                        <a href="https://family.legalaid.bc.ca/bc-legal-system/court-orders/write-order/tips-writing-supreme-court-orders"
                            target="_blank">Write draft order</a>
                         - List what orders you want the court to make.
                     </li>
@@ -810,10 +810,10 @@
     <h3>Completed Forms</h3>
     <p>
         If you're not sure whether you've filled out the documents correctly, get some
-        <a href="https://familylaw.lss.bc.ca/help/who_LegalAdvice.php" target="_blank">legal advice</a> before you file your documents — from
-        <a href="https://familylaw.lss.bc.ca/help/who_FamilyDutyCounsel.php" target="_blank">family duty counsel</a>
+        <a href="https://family.legalaid.bc.ca/bc-legal-system/legal-help/legal-advice-and-legal-aid/tips-about-getting-legal-help" target="_blank">legal advice</a> before you file your documents — from
+        <a href="https://family.legalaid.bc.ca/visit/family-duty-counsel-family-lawyers" target="_blank">family duty counsel</a>
         or (in Vancouver) from the Vancouver
-        <a href="https://familylaw.lss.bc.ca/help/jacSelfHelpAndInfoServices.php" target="_blank">Justice Access Centre</a> Self-Help and
+        <a href="https://family.legalaid.bc.ca/visit/justice-access-centre-vancouver-victoria-and-nanaimo" target="_blank">Justice Access Centre</a> Self-Help and
         Information Services.
     </p>
     <h3>Signing, Swearing and Completing Forms</h3>

--- a/edivorce/apps/core/templates/incomplete.html
+++ b/edivorce/apps/core/templates/incomplete.html
@@ -25,7 +25,7 @@
             Court of B.C. website</a>.
     </p>
     <p>
-        A <a target="_blank" href="https://familylaw.lss.bc.ca/guides/divorce/divJoint_courtForms.php">listing
+        A <a target="_blank" href="https://family.legalaid.bc.ca/separation-divorce/getting-a-divorce/do-your-own-uncontested-divorce/joint-application#0">listing
         of forms</a> that may be required for a Joint Divorce can also be found on the Family Law
         in B.C. website.
     </p>

--- a/edivorce/apps/core/templates/legal.html
+++ b/edivorce/apps/core/templates/legal.html
@@ -8,11 +8,11 @@
 <h4>JUSTICE ACCESS CENTRES &amp; FAMILY JUSTICE CENTRES</h4>
 <p>
     <a href="https://www2.gov.bc.ca/gov/content/justice/about-bcs-justice-system/jac" target="_blank">Justice Access Centres</a>
-    and <a href="https://www2.gov.bc.ca/gov/content/life-events/divorce/family-justice/who-can-help/family-justice-counsellors" target="_blank">Family Justice Centres</a> 
-    across BC have Family Justice Counsellors and Child Support Officers specially trained to help families resolve 
+    and <a href="https://www2.gov.bc.ca/gov/content/life-events/divorce/family-justice/who-can-help/family-justice-counsellors" target="_blank">Family Justice Centres</a>
+    across BC have Family Justice Counsellors and Child Support Officers specially trained to help families resolve
     their issues about guardianship, parenting arrangements (time and responsibilities), contact and child / spousal support.
-    There is no charge for their services.  
-    Services are available whether you are looking to establish or vary existing arrangements; and may include 
+    There is no charge for their services.
+    Services are available whether you are looking to establish or vary existing arrangements; and may include
     provision of legal information and information on court processes and options for resolution, mediation and referrals.
 </p>
 
@@ -23,7 +23,7 @@
 
 <h4>Online resources</h4>
 <p>
-    You may want to look at the <a href="https://familylaw.lss.bc.ca/guides#separation-divorce" target="_blank">Divorce self-help guide</a>
+    You may want to look at the <a href="https://family.legalaid.bc.ca/guides#separation-divorce" target="_blank">Divorce self-help guide</a>
     on the Family Law in British Columbia website for a step-by-step guide. You can also visit
     <a href="http://wiki.clicklaw.bc.ca/index.php/Separation_%26_Divorce" target="_blank">ClickLaw</a> and the
     <a href="http://www.justiceeducation.ca/" target="_blank">Justice Education Society</a> for online legal information.

--- a/edivorce/apps/core/templates/partials/fact_sheets/fact_sheet_b.html
+++ b/edivorce/apps/core/templates/partials/fact_sheets/fact_sheet_b.html
@@ -53,7 +53,7 @@
                                        target="_blank">Federal Child Support Guidelines: Step-by-Step Guide</a>
                             </li>
                             <li>
-                                The <a href="https://familylaw.lss.bc.ca/resources/fact_sheets/child_support.php#fortyPercentPrinciple"
+                                The <a href="https://family.legalaid.bc.ca/finances-support/child-spousal-support/child-support#fortyPercentPrinciple"
                                        target="_blank">child support</a> page on the Family Law in B.C. website.
                             </li>
                         </ul>

--- a/edivorce/apps/core/templates/partials/tooltips/forms/draft_final_order_52.html
+++ b/edivorce/apps/core/templates/partials/tooltips/forms/draft_final_order_52.html
@@ -5,12 +5,12 @@
 {% endblock %}
 
 {% block inner %}
-    A draft Final Order sets our what orders (decision) you want the court to make. You and your spouse are responsible for writing out the order. 
+    A draft Final Order sets our what orders (decision) you want the court to make. You and your spouse are responsible for writing out the order.
     The judge or master who reviews your case doesn't write the order. The final order you draft will become your divorce order, once the judge has signed it.
-    
+
     <ul>
         <li>
-            <a href="https://familylaw.lss.bc.ca/resources/fact_sheets/tipsForDraftingOrders.php" target="_blank">Write draft order</a> - List what orders you want the court to make.
+            <a href="https://family.legalaid.bc.ca/bc-legal-system/court-orders/write-order/tips-writing-supreme-court-orders" target="_blank">Write draft order</a> - List what orders you want the court to make.
         </li>
         <li>
             <b>File draft order</b> when you file the other forms and documents at the court registry
@@ -19,13 +19,13 @@
             If the judge or master makes the order you ask for, they'll sign the draft order you filed and it becomes your court order.
         </li>
         <li>
-            If there's a problem with your order and the judge or master doesn't approve it, the court registry will let you know. 
+            If there's a problem with your order and the judge or master doesn't approve it, the court registry will let you know.
             You might have to draft another version of the order or appear in court to give the judge or master more information about what you wrote in the order.
         </li>
     </ul>
     <br/><br/>
     This form is created automatically by this tool.
-    
+
 {% endblock %}
 
 {% block label %}

--- a/edivorce/apps/core/templates/prequalification/step_01.html
+++ b/edivorce/apps/core/templates/prequalification/step_01.html
@@ -52,7 +52,7 @@
                 <p>No, you aren't married, but after two years, you have a lot
                 of the same rights as a married couple would.  For more
                 information refer to the booklet called
-                <a href="https://familylaw.lss.bc.ca/resources/publications/pub.php?pub=347" target="_blank">
+                <a href="https://family.legalaid.bc.ca/resources/publications/pub.php?pub=347" target="_blank">
                 Living Together or Living Apart: Common-Law Relationships,
                 Marriage, Separation and Divorce</a>, on the Family Law in B.C.
                 website.</p>

--- a/edivorce/apps/core/templates/prequalification/step_03.html
+++ b/edivorce/apps/core/templates/prequalification/step_03.html
@@ -119,7 +119,7 @@
     <div class="radio">
       <label>
         {% input_field type="radio" name="try_reconcile_after_separated" value="YES" data_target_id="reconciliation_period" data_reveal_target="true" %}
-        Yes, {% spouse_name if_blank="my spouse" %} and I lived together again during the following 
+        Yes, {% spouse_name if_blank="my spouse" %} and I lived together again during the following
         period(s) in an unsuccessful attempt to reconcile
       </label>
     </div>
@@ -216,7 +216,7 @@ upon.</p>
 <p>Some couples choose to separate but still live in the same house. A lawyer can tell you what factors courts may consider when they are deciding if you are separated.</p>
 
 <p>A <a
-  href="https://familylaw.lss.bc.ca/resources/fact_sheets/howToProveYouAreSeparatedIfYouStillLiveTogether.php"
+  href="https://family.legalaid.bc.ca/separation-divorce/going-through-separation/proving-youre-separated-if-you-still-live-together"
   target="_blank">list of activities and behaviours</a> that the courts
 consider to be indicators of a couple being separated can be found on the
 Family Law in B.C. website.</p>

--- a/edivorce/apps/core/templates/prequalification/step_04.html
+++ b/edivorce/apps/core/templates/prequalification/step_04.html
@@ -207,7 +207,7 @@
             target="_blank">Supreme Court of B.C. website</a>.</p>
 
             <p>A
-              <a href="https://familylaw.lss.bc.ca/guides/divorce/divJoint_courtForms.php"
+              <a href="https://family.legalaid.bc.ca/separation-divorce/getting-a-divorce/do-your-own-uncontested-divorce/joint-application#0"
               target="_blank">listing of forms</a> that may be required for a
               Joint Divorce can also be found on the Family Law in B.C. website.
             </p>
@@ -231,7 +231,7 @@
 
         <div class="information-message bg-danger hard-stop" id="children_live_with_others_stop" hidden>
             <p>
-                This application does not currently support situations where the children do not live with one or both of the spouses. Please click the 
+                This application does not currently support situations where the children do not live with one or both of the spouses. Please click the
                 <a href="{% url 'legal' %}" target="_blank">Get Help</a>
                  button in the top right of this application to view other resources that can help you.
             </p>

--- a/edivorce/apps/core/templates/prequalification/step_06.html
+++ b/edivorce/apps/core/templates/prequalification/step_06.html
@@ -80,7 +80,7 @@
             <p>Some couples choose to separate but still live in the same house. A lawyer can tell you what factors courts may consider when they are deciding if you are separated.</p>
             <p>
                 A list of activities and behaviours that the
-                <a href="https://familylaw.lss.bc.ca/resources/fact_sheets/howToProveYouAreSeparatedIfYouStillLiveTogether.php" target="_blank">
+                <a href="https://family.legalaid.bc.ca/separation-divorce/going-through-separation/proving-youre-separated-if-you-still-live-together" target="_blank">
                     courts consider to be indicators of a couple being separated</a> can be found on the Family Law in B.C. website.
             </p>
         </div>

--- a/edivorce/apps/core/templates/question/01_orders.html
+++ b/edivorce/apps/core/templates/question/01_orders.html
@@ -78,7 +78,7 @@
                 </ul>
                 <p>
                     For more information, please refer to the
-                    <a href="https://familylaw.lss.bc.ca/resources/fact_sheets/spousal_support.php"
+                    <a href="https://family.legalaid.bc.ca/finances-support/child-spousal-support/spousal-support"
                        target="_blank">Spousal Support fact sheet</a> on the Family Law in B.C. website.
                 </p>
             </div>
@@ -126,7 +126,7 @@
         <p>
             Anything you own including real estate, bank accounts, cars and
             RRSPs. For more information, please refer to the
-            <a href="https://familylaw.lss.bc.ca/resources/fact_sheets/debtsAfterSeparation.php"
+            <a href="https://family.legalaid.bc.ca/finances-support/property-debt/dealing-debts-after-you-separate"
                target="_blank">Dealing with Debts After Separation fact sheet</a> on
             the Family Law in B.C. website.
         </p>
@@ -242,7 +242,7 @@
                     </p>
                     <p>
                         More information on which court you may need to go to can be found on the
-                        <a href="https://familylaw.lss.bc.ca/resources/fact_sheets/choosing_court.php" target="_blank">
+                        <a href="https://family.legalaid.bc.ca/bc-legal-system/court-orders/get-order-bc/do-you-need-go-provincial-family-court-or-supreme-court" target="_blank">
                             Family Law in B.C. website</a>
                         and the
                         <a href="https://www2.gov.bc.ca/gov/content/life-events/divorce/family-justice/your-options/going-to-court/which-court-should-i-go-to"
@@ -387,7 +387,7 @@
 </p>
 <p>
     More information on
-    <a href="https://familylaw.lss.bc.ca/resources/fact_sheets/allAboutCourtOrders.php"
+    <a href="https://family.legalaid.bc.ca/bc-legal-system/court-orders/final-and-interim-court-orders"
        target="_blank">Court Orders</a> can be found on the Family Law in B.C. website.
 </p>
 {% endblock %}

--- a/edivorce/apps/core/templates/question/06_children_income_expenses.html
+++ b/edivorce/apps/core/templates/question/06_children_income_expenses.html
@@ -276,7 +276,7 @@
         <div class="collapse" id="collapse_change_order">
             <div>
                 Click
-                <a href="https://familylaw.lss.bc.ca/bc-legal-system/court-orders/change-order-or-set-aside-agreement-made-bc" target="_blank">here</a>
+                <a href="https://family.legalaid.bc.ca/bc-legal-system/court-orders/change-order-or-set-aside-agreement-made-bc" target="_blank">here</a>
                 for 'step by step' instructions
             </div>
         </div>
@@ -528,7 +528,7 @@
     </p>
     <p>
         For more information on
-        <a href="https://familylaw.lss.bc.ca/resources/fact_sheets/child_support.php" target="_blank">undue hardship</a>
+        <a href="https://family.legalaid.bc.ca/finances-support/child-spousal-support/child-support#undueHardship" target="_blank">undue hardship</a>
         refer to the Family Law of B.C. website.
     </p>
 
@@ -553,7 +553,7 @@
     </p>
     <p>
         More details on what are
-        <a href="https://familylaw.lss.bc.ca/resources/fact_sheets/child_support.php" target="_blank">
+        <a href="https://family.legalaid.bc.ca/finances-support/child-spousal-support/child-support" target="_blank">
             generally considered special or extraordinary expenses
         </a>
         can be found on the Family Law of B.C. website.

--- a/edivorce/apps/core/templates/question/06_children_what_for.html
+++ b/edivorce/apps/core/templates/question/06_children_what_for.html
@@ -26,7 +26,7 @@
                 {% comment "Child support guideline value scenarios" %}
                     If split or shared custody, prepopulate the field with the value from factsheet.
                     If sole custody, prepopulate the field with the value from "What is the monthly child support amount that is payable".
-                    Assumption: If neither factsheet b (shared) nor factsheet c (split) 
+                    Assumption: If neither factsheet b (shared) nor factsheet c (split)
                                 shows up, assume it is sole custody as there will be only
                                 three cases, sole, split, or shared custody.
                 {% endcomment %}
@@ -139,7 +139,7 @@
                 <p>
                     If you wish to file your separation agreement the parts of the agreement that deal with
                     parenting and support can be enforced as if they were in a court order. More information on
-                    <a href="https://familylaw.lss.bc.ca/guides/mini/fileAgreementSC.php" target="_blank">
+                    <a href="https://family.legalaid.bc.ca/bc-legal-system/legal-forms-documents/agreements/file-your-agreement-supreme-court" target="_blank">
                         how to file your agreement
                     </a>
                     can be found on the Family Law website.
@@ -160,7 +160,7 @@
             </p>
             <p>
                 If you
-                <a href="https://familylaw.lss.bc.ca/guides/mini/fileAgreementSC.php" target="_blank">
+                <a href="https://family.legalaid.bc.ca/bc-legal-system/legal-forms-documents/agreements/file-your-agreement-supreme-court" target="_blank">
                     wish to file your separation agreement
                 </a>, the parts of the agreement that deal
                 with parenting and support can be {% include "partials/tooltips/children/enforceable.html" %}
@@ -200,7 +200,7 @@
             <p>
                If you wish to file your separation agreement, the parts of the agreement that deal with parenting and
                 support can be enforced as if they were in a court order. More information on
-                <a href="https://familylaw.lss.bc.ca/guides/mini/fileAgreementSC.php" target="_blank">
+                <a href="https://family.legalaid.bc.ca/bc-legal-system/legal-forms-documents/agreements/file-your-agreement-supreme-court" target="_blank">
                     how to file your agreement
                 </a>
                 can be found on the Family Law website.
@@ -307,7 +307,7 @@
             <a href="http://www.courts.gov.bc.ca/supreme_court/practice_and_procedure/family_law_orders/picklist_family_orders.pdf" target="_blank">
                 The Supreme Court Family Order Pick List
             </a> which sets out standard terms for most of the usual orders made in family cases. Refer to the fact sheet
-            <a href="https://familylaw.lss.bc.ca/resources/fact_sheets/child_support.php" target="_blank">
+            <a href="https://family.legalaid.bc.ca/finances-support/child-spousal-support/child-support" target="_blank">
                 Child Support
             </a> by the Legal Services Society for more information.
         </p>
@@ -373,7 +373,7 @@
                 <p>
                     There are big differences in how the Divorce Act and the Family Law Act deal with some issues,
                     especially parenting. For more information, see the fact sheet
-                    <a href="https://familylaw.lss.bc.ca/resources/fact_sheets/parentingApart.php" target="_blank">
+                    <a href="https://family.legalaid.bc.ca/children/parenting-guardianship/parenting/parenting-apart" target="_blank">
                         Parenting apart
                     </a> and the other fact sheets it links to.
                 </p>
@@ -411,7 +411,7 @@
         you must only consider the child’s best interests. And if you go to court, the judge can
         only consider the child’s best interests in making parenting orders. For more information
         on the
-        <a href="https://familylaw.lss.bc.ca/resources/fact_sheets/bestInterestsOfChild.php" target="_blank">
+        <a href="https://family.legalaid.bc.ca/children/parenting-guardianship/best-interests-child" target="_blank">
             best interests of the child
         </a>
         please refer to the Family Law  in B.C. website.

--- a/edivorce/apps/core/templates/question/06_children_your_children.html
+++ b/edivorce/apps/core/templates/question/06_children_your_children.html
@@ -216,7 +216,7 @@
                 </ul>
                 <p>
                     For more information on
-                    <a href="https://familylaw.lss.bc.ca/resources/fact_sheets/step_parents_rights.php"
+                    <a href="https://family.legalaid.bc.ca/children/parenting-guardianship/parenting/step-parents-rights-and-responsibilities"
                        target="_blank">step-parents' rights and responsibilities</a>
                     please refer to the Family Law of B.C. website.
                 </p>

--- a/edivorce/apps/core/templates/question/07_support.html
+++ b/edivorce/apps/core/templates/question/07_support.html
@@ -14,7 +14,7 @@
 
 <div class="question-well {% if spouse_support_details_error %}error{% endif %}">
     <h3>
-        {% you_name if_blank="Claimant 1" %} and 
+        {% you_name if_blank="Claimant 1" %} and
         {% spouse_name if_blank="Claimant 2" %}
         are asking for an {% include "partials/tooltips/order.html" %}
         for spousal support as follows:{% if spouse_support_details_error %}{% include 'partials/required.html' %}{% endif %}
@@ -57,7 +57,7 @@
                 or a <a href="{% url 'legal' %}" target="_blank">family justice
                 counsellor</a> for help. For more information, please see the
                 fact sheet
-                <a href="https://familylaw.lss.bc.ca/resources/fact_sheets/spousal_support.php"
+                <a href="https://family.legalaid.bc.ca/finances-support/child-spousal-support/spousal-support"
                 target="_blank">Spousal Support</a> on the Family Law in B.C.
               website.
             </p>
@@ -77,7 +77,7 @@
             detailed in a separation agreement.</p>
             <p>Many couples come to an agreement about spousal support  outside
             of court and capture the details in a
-            <a href="https://familylaw.lss.bc.ca/resources/fact_sheets/spousal_support.php"
+            <a href="https://family.legalaid.bc.ca/bc-legal-system/legal-forms-documents/agreements/making-agreement-after-you-separate"
             target="_blank">separation agreement</a>.  "Agreements that are
             filed with the court can be enforced — they have the same force as a
             court order.  They can also be set aside (cancelled) if the situation
@@ -101,7 +101,7 @@
             <p>
                 For help on what factors to consider, and details to include in
                 your spousal support agreement, refer to the online tool,
-                <a href="https://familylaw.lss.bc.ca/guides/separation/supportSpouse.php"
+                <a href="https://family.legalaid.bc.ca/children/parenting-guardianship/parenting/parenting-apart"
                 target="_blank">How to Write Your Own Separation Agreement</a>,
                 on the Family Law in B.C. website.
             </p>
@@ -200,7 +200,7 @@
             <p>There are big differences in how the Divorce Act and the
             Family Law Act deal with some issues, especially parenting. For
             more information on
-            <a href="https://familylaw.lss.bc.ca/resources/fact_sheets/parentingApart.php"
+            <a href="https://family.legalaid.bc.ca/children/parenting-guardianship/parenting/parenting-apart"
                target="_blank">which laws apply to your situation</a>
             please refer to the Family Law of B.C. website.</p>
 
@@ -226,7 +226,7 @@
                 <h1 class="modal-title">Spousal Support</h1>
             </div>
             <div class="modal-body">
-                <p>Okay {% you_name if_blank='Claimant 1' %}, now we need to ask 
+                <p>Okay {% you_name if_blank='Claimant 1' %}, now we need to ask
                 you several questions about spousal support.</p>
 
                 <p>Spousal support is paid by one spouse to financially support
@@ -278,7 +278,7 @@
             into account the income of both spouses, how long you were married,
             and whether you have children.</p>
             <p>For more information, see the Department of Justice website on
-                <a href="https://familylaw.lss.bc.ca/resources/fact_sheets/spousal_support.php"
+                <a href="https://family.legalaid.bc.ca/finances-support/child-spousal-support/spousal-support"
                   target="_blank">spousal support.</a></p>
         </div>
         <div>
@@ -315,7 +315,7 @@
           target="_blank">Financial Statement Form (F8)</a> and file it
         with the court for orders related to support. For help, refer to
         the guide
-        <a href="https://familylaw.lss.bc.ca/guides/mini/howToFillFinanState_SC.php"
+        <a href="https://family.legalaid.bc.ca/bc-legal-system/legal-forms-documents/filling-out-court-forms/complete-supreme-court-financial#0"
         target="_blank">How to deal with a Supreme Court Financial
         Statement,</a> produced by the Legal Services Society.</p>
 

--- a/edivorce/apps/core/templates/question/08_property.html
+++ b/edivorce/apps/core/templates/question/08_property.html
@@ -109,8 +109,8 @@
             </ul>
             <p>The Family Law web site has an online separation agreement tool
             that details some of the items to consider when
-                <a href="https://familylaw.lss.bc.ca/guides/separation/property.php" target="_blank">dividing property</a> and
-                <a href="https://familylaw.lss.bc.ca/guides/separation/debt.php" target="_blank">debt</a>.</p>
+                <a href="https://family.legalaid.bc.ca/guides/separation/property" target="_blank">dividing property</a> and
+                <a href="https://family.legalaid.bc.ca/guides/separation/debt" target="_blank">debt</a>.</p>
         </div>
     </div>
     {% input_field type="textarea" name="how_to_divide_property_debt" rows="8" cols="65" class="response-textarea" %}
@@ -143,7 +143,7 @@
     </p>
     <div>
         <label>
-            {% you_name if_blank="Claimant 1" %} and 
+            {% you_name if_blank="Claimant 1" %} and
             {% spouse_name if_blank="Claimant 2" %}
             ask for an order respecting an interest in property or for
             compensation instead of an interest in that property, as follows:
@@ -160,9 +160,9 @@
                 <h1 class="modal-title">Property and Debt</h1>
             </div>
             <div class="modal-body">
-                <p>{% you_name if_blank="Claimant 1" %}, next up let's go over 
-                some questions pertaining to the division of property and debt. 
-                The answers you provide will be used to populate what's called 
+                <p>{% you_name if_blank="Claimant 1" %}, next up let's go over
+                some questions pertaining to the division of property and debt.
+                The answers you provide will be used to populate what's called
                 a Draft Final Order (Form 52). </p>
 
                 <p>A draft final order sets out what orders (decisions) you
@@ -200,11 +200,11 @@
             target="_blank">Family Justice section</a> of the BC Government web
         site. </li>
         <li><a
-            href="https://familylaw.lss.bc.ca/resources/fact_sheets/dividePropertyAndDebts.php"
+            href="https://family.legalaid.bc.ca/finances-support/property-debt/dividing-property-and-debts-after-you-separate"
             target="_blank">Dividing family property and debts</a> on the
         Family Law in British Columbia website</li>
         <li><a
-            href="https://familylaw.lss.bc.ca/resources/publications/pub.php?pub=347"
+            href="https://family.legalaid.bc.ca/publications/living-together-or-living-apart?pub=347"
             target="_blank">Living Together or Living Apart</a>, a booklet
         about the family law basics in B.C.</li>
         <li><a


### PR DESCRIPTION
Updated all links from https://familylaw.lss.bc.ca/ to their redirected equivalents at https://family.legalaid.bc.ca/
There is some extra spaces that were automatically removed, but they shouldn't impact anything.