### PR TITLE
Updates to Form 1 and Form 35

### DIFF
--- a/edivorce/apps/core/templates/pdf/form1.html
+++ b/edivorce/apps/core/templates/pdf/form1.html
@@ -204,10 +204,29 @@
                     <td colspan="2"><strong>B. Grounds for claim for divorce:</strong></td>
                 </tr>
                 <tr>
+                  <td colspan="2">
+                    <div>
+                      <span class="td-list-item"> {% checkbox True %}</span>
+                      Divorce is claimed as a result of having lived separate and apart.
+                    </div>
+                    <br>
+                    <div>
+                      <span class="td-list-item"> {% checkbox False %}</span>
+                      Divorce is claimed on grounds other than having lived separate and apart.
+                    </div>
+                  </td>
+                </tr>
+                <tr>
                     <td colspan="2">
-                      <span class="td-list-item">(i) {% checkbox responses.separation_date %}</span>
-                      Claimant 1 and Claimant 2 have lived separate and apart
-                      since {% response responses.separation_date|date_formatter %}
+                      <div>
+                        Divorce claimed as a result of having lived separate and apart.
+                      </div>
+                      <br>
+                      <div>
+                        <span class="td-list-item">(i) {% checkbox responses.separation_date %}</span>
+                        Claimant 1 and Claimant 2 have lived separate and apart
+                        since {% response responses.separation_date|date_formatter %}
+                      </div>
                     </td>
                 </tr>
                 <tr>
@@ -227,11 +246,11 @@
                           {% checkbox try_reconcile_after_separated='YES' %}
                         </span>
                         <div class="td-list-text">
-                          Claimant 1 and Claimant 2 have lived together again
-                          during the following period(s), in an unsuccessful
-                          attempt to reconcile: <br>
-                          [<em>give dates of period(s)</em>]<br><br>
-
+                          <p>
+                            Claimant 1 and Claimant 2 have lived together again
+                            during the following period(s), in an unsuccessful
+                            attempt to reconcile:
+                          </p>
                           <table class="table table-bordered table-fixed">
   {% multiple_values_to_list source=responses.reconciliation_period as periods %}
   {% if periods and responses.try_reconcile_after_separated == 'YES' %}
@@ -257,9 +276,21 @@
                     <td colspan="2">
                       <span class="td-list-item">(ii) {% checkbox False %}</span>
                       <div class="td-list-text">
-                        <strong>Other grounds</strong>,
-                        under section 8 (2) (b) of the <em> Divorce Act </em> (Canada):
-                        <span class="form-entry form-textarea not-complete">&nbsp;</span>
+                        <div>
+                          <strong>Other grounds</strong>,
+                          under section 8 (2) (b) of the <em> Divorce Act </em> (Canada):
+                        </div>
+                        <br>
+                        <div>
+                          <span class="td-list-item"> {% checkbox False %}</span>
+                          Adultery (the respondent has committed adultery)
+                        </div>
+                        <br>
+                        <div>
+                          <span class="td-list-item"> {% checkbox False %}</span>
+                          Cruelty (the respondent has treated the applicant with physical or mental cruelty
+                          of such a kind as to make continued cohabitation intolerable)
+                        </div>
                       </div>
                     </td>
                 </tr>

--- a/edivorce/apps/core/templates/pdf/form35.html
+++ b/edivorce/apps/core/templates/pdf/form35.html
@@ -79,10 +79,10 @@
             {% checkbox True %} certificate of the registrar in Form F36;
           </p>
           <p>
-            {% checkbox True %} filing fee.
+            {% checkbox True %} filing fee;
           </p>
           <p>
-            {% checkbox False %} proof of service of the notice of family claim or counterclaim, as the case may be.
+            {% checkbox False %} proof of service of the notice of family claim or counterclaim, as the case may be;
           </p>
           <p>
             {% if responses.num_actual_children > 0 and 'Child support' in responses.want_which_orders %}
@@ -90,13 +90,19 @@
             {% else %}
               {% checkbox False %}
             {% endif %}
-            Child Support Affidavit in Form F37.
+            Child Support Affidavit in Form F37;
           </p>
           <p>
             {% checkbox True %} affidavit in Form F38;
           </p>
           <p>
-            {% checkbox False %} signed consent order.
+            {% checkbox False %} signed consent order;
+          </p>
+          <p>
+            {% checkbox False %} notice of withdrawal;
+          </p>
+          <p>
+            {% checkbox False %} other.
           </p>
         </div>
 


### PR DESCRIPTION
- Restructured Form 1 Grounds for Divorce to look like the new form
- Replaced "Other Grounds" text box with checkboxes
- Removed unnecessary hint for entry
- Added two list items to Form 38
- Cleaned up use of ; and . in the list of Form 38