### PR TITLE
DIV-1430: Fixed Final Filing HTML issues

### DIFF
--- a/edivorce/apps/core/templates/partials/tooltips/forms/agreement_to_annual_income_9.html
+++ b/edivorce/apps/core/templates/partials/tooltips/forms/agreement_to_annual_income_9.html
@@ -5,10 +5,10 @@
 {% endblock %}
 
 {% block inner %}
-    This form needs to be provided to the Registry as they require it as it is required when reviewing your divorce application. 
+    This form needs to be provided to the Registry as they require it as it is required when reviewing your divorce application.
     It shows the judge that your application has been checked and is complete.
     <br/><br/>
-    This form requires you to complete it either by hand or using <a href="https://justice.gov.bc.ca/divorce/dashboard/help_saving_pdf" target="_blank">Adobe Acrobat Reader</a>.
+    This form requires you to complete it either by hand or using <a href='https://justice.gov.bc.ca/divorce/dashboard/help_saving_pdf' target='_blank'>Adobe Acrobat Reader</a>.
 {% endblock %}
 
 {% block label %}

--- a/edivorce/apps/core/templates/partials/tooltips/forms/desk_order_38.html
+++ b/edivorce/apps/core/templates/partials/tooltips/forms/desk_order_38.html
@@ -8,7 +8,7 @@
     <p>This form sets out all the facts of your marriage and separation for the court and gives information about parenting time if you have children.</p>
     <p>Since your divorce won't require an appearance before a judge, you must fill out and swear / affirm an Affidavit Desk Order Divorce Form (F38). This document sets out the facts of your marriage and separation.</p>
     <p>The fee for swearing / affirming this document is $40 per affidavit if sworn at a court registry.</p>
-    <br/><br/>
+    <br/>
     This form is created automatically by this tool.
 {% endblock %}
 

--- a/edivorce/apps/core/templates/partials/tooltips/forms/draft_final_order_52.html
+++ b/edivorce/apps/core/templates/partials/tooltips/forms/draft_final_order_52.html
@@ -10,7 +10,7 @@
 
     <ul>
         <li>
-            <a href="https://family.legalaid.bc.ca/bc-legal-system/court-orders/write-order/tips-writing-supreme-court-orders" target="_blank">Write draft order</a> - List what orders you want the court to make.
+            <a href='https://family.legalaid.bc.ca/bc-legal-system/court-orders/write-order/tips-writing-supreme-court-orders' target='_blank'>Write draft order</a> - List what orders you want the court to make.
         </li>
         <li>
             <b>File draft order</b> when you file the other forms and documents at the court registry
@@ -23,7 +23,7 @@
             You might have to draft another version of the order or appear in court to give the judge or master more information about what you wrote in the order.
         </li>
     </ul>
-    <br/><br/>
+    <br/>
     This form is created automatically by this tool.
 
 {% endblock %}

--- a/edivorce/apps/core/templates/partials/tooltips/forms/identification_of_applicant.html
+++ b/edivorce/apps/core/templates/partials/tooltips/forms/identification_of_applicant.html
@@ -7,7 +7,7 @@
 {% block inner %}
     This form is used by the Court to notify Vital Statistics of court-ordered legal changes of name.
     <br/><br/>
-    This form requires you to complete it either by hand or using <a href="https://justice.gov.bc.ca/divorce/dashboard/help_saving_pdf" target="_blank">Adobe Acrobat Reader</a>.
+    This form requires you to complete it either by hand or using <a href='https://justice.gov.bc.ca/divorce/dashboard/help_saving_pdf' target='_blank'>Adobe Acrobat Reader</a>.
 {% endblock %}
 
 {% block label %}

--- a/edivorce/apps/core/templates/partials/tooltips/forms/joint_divorce_proceedings.html
+++ b/edivorce/apps/core/templates/partials/tooltips/forms/joint_divorce_proceedings.html
@@ -5,11 +5,11 @@
 {% endblock %}
 
 {% block inner %}
-    This form is for the central divorce registry in Ottawa. 
-    They use the form to ensure there is no other divorce proceeding pending in Canada. 
+    This form is for the central divorce registry in Ottawa.
+    They use the form to ensure there is no other divorce proceeding pending in Canada.
     They also keep track of all divorces in Canada.
     <br/><br/>
-    This form requires you to complete it either by hand or using <a href="https://justice.gov.bc.ca/divorce/dashboard/help_saving_pdf" target="_blank">Adobe Acrobat Reader</a>.
+    This form requires you to complete it either by hand or using <a href='https://justice.gov.bc.ca/divorce/dashboard/help_saving_pdf' target='_blank'>Adobe Acrobat Reader</a>.
 {% endblock %}
 
 {% block label %}


### PR DESCRIPTION
The double quotes in some of the partials were causing issues with the final HTML page. Changing to single quotes seems to have fixed it.
Also removed an extra break because one of the tooltips looked more spaced out.