### PR TITLE
DEV-1288: Made translation independent of cert

### DIFF
--- a/edivorce/apps/core/templates/dashboard/final_filing.html
+++ b/edivorce/apps/core/templates/dashboard/final_filing.html
@@ -135,9 +135,9 @@
                         </li>
                         {% if original_marriage_certificate == 'YES' %}
                             <li>{% include "partials/tooltips/forms/proof_of_marriage.html" %}</li>
-                            {% if marriage_certificate_in_english == 'NO' %}
-                                <li>{% include "partials/tooltips/forms/affidavit_of_translation.html" %} sworn / affirmed by a translator</li>
-                            {% endif %}
+                        {% endif %}
+                        {% if marriage_certificate_in_english == 'NO' %}
+                            <li>{% include "partials/tooltips/forms/affidavit_of_translation.html" %} sworn / affirmed by a translator</li>
                         {% endif %}
                         <li>{% include "partials/tooltips/forms/joint_divorce_proceedings.html" %}</li>
                         <li>{% include "partials/tooltips/forms/requisition_form_35.html" %} signed by both you and your spouse</li>
@@ -211,9 +211,9 @@
                         </li>
                         {% if original_marriage_certificate == 'YES' %}
                             <li>{% include "partials/tooltips/forms/proof_of_marriage.html" %}</li>
-                            {% if marriage_certificate_in_english == 'NO' %}
-                                <li>{% include "partials/tooltips/forms/affidavit_of_translation.html" %} sworn / affirmed by a translator</li>
-                            {% endif %}
+                        {% endif %}
+                        {% if marriage_certificate_in_english == 'NO' %}
+                            <li>{% include "partials/tooltips/forms/affidavit_of_translation.html" %} sworn / affirmed by a translator</li>
                         {% endif %}
                         <li>{% include "partials/tooltips/forms/joint_divorce_proceedings.html" %}</li>
                         <li>{% include "partials/tooltips/forms/requisition_form_35.html" %} signed by both you and your spouse</li>

--- a/edivorce/apps/core/utils/efiling_documents.py
+++ b/edivorce/apps/core/utils/efiling_documents.py
@@ -30,7 +30,7 @@ def forms_to_file(responses_dict, initial=False):
             uploaded.append({'doc_type': 'AFF', 'party_code': 0})
             uploaded.append({'doc_type': 'EFSS0', 'party_code': 0})
 
-        if responses_dict.get('marriage_certificate_in_english') == 'NO':
+        if provide_certificate_later and responses_dict.get('marriage_certificate_in_english') == 'NO':
             uploaded.append({'doc_type': 'AFTL', 'party_code': 0})
             uploaded.append({'doc_type': 'EFSS1', 'party_code': 1})
 

--- a/edivorce/apps/core/utils/efiling_documents.py
+++ b/edivorce/apps/core/utils/efiling_documents.py
@@ -26,13 +26,13 @@ def forms_to_file(responses_dict, initial=False):
         if provide_marriage_certificate:
             uploaded.append({'doc_type': 'MC', 'party_code': 0})
 
-            if responses_dict.get('marriage_certificate_in_english') == 'NO':
-                uploaded.append({'doc_type': 'AFTL', 'party_code': 0})
-                uploaded.append({'doc_type': 'EFSS1', 'party_code': 1})
-
         elif not provide_certificate_later:
             uploaded.append({'doc_type': 'AFF', 'party_code': 0})
             uploaded.append({'doc_type': 'EFSS0', 'party_code': 0})
+
+        if responses_dict.get('marriage_certificate_in_english') == 'NO':
+            uploaded.append({'doc_type': 'AFTL', 'party_code': 0})
+            uploaded.append({'doc_type': 'EFSS1', 'party_code': 1})
 
         uploaded.append({'doc_type': 'RDP', 'party_code': 0})
 


### PR DESCRIPTION
The certificate of translation only showed up in the final filing if you were also providing a marriage certificate. But there's a case when you are providing the certificate _later_ and still need to translate it that should also require a certificate of translation. So I made the conditional for the CoT independent of the marriage certificate.