### PR TITLE
DIV-1469: Fixed failing tests on translated CoM

### DIFF
--- a/edivorce/apps/core/templates/dashboard/final_filing.html
+++ b/edivorce/apps/core/templates/dashboard/final_filing.html
@@ -139,7 +139,7 @@
                         {% if marriage_certificate_in_english == 'NO' %}
                             <li>{% include "partials/tooltips/forms/affidavit_of_translation.html" %} sworn / affirmed by a translator</li>
                         {% endif %}
-                        {% if provide_certificate_later == 'NO' %}
+                        {% if original_marriage_certificate == 'NO' and provide_certificate_later == 'NO' %}
                             <li>{% include "partials/tooltips/forms/affidavit_of_no_marriage_certificate.html" %}</li>
                         {% endif %}
                         <li>{% include "partials/tooltips/forms/joint_divorce_proceedings.html" %}</li>
@@ -218,7 +218,7 @@
                         {% if marriage_certificate_in_english == 'NO' %}
                             <li>{% include "partials/tooltips/forms/affidavit_of_translation.html" %} sworn / affirmed by a translator</li>
                         {% endif %}
-                        {% if provide_certificate_later == 'NO' %}
+                        {% if original_marriage_certificate == 'NO' and provide_certificate_later == 'NO' %}
                             <li>{% include "partials/tooltips/forms/affidavit_of_no_marriage_certificate.html" %}</li>
                         {% endif %}
                         <li>{% include "partials/tooltips/forms/joint_divorce_proceedings.html" %}</li>

--- a/edivorce/apps/core/templates/dashboard/print_form.html
+++ b/edivorce/apps/core/templates/dashboard/print_form.html
@@ -656,7 +656,7 @@
     </div>
     {% endif %}
 
-    {% if original_marriage_certificate == 'NO' %}
+    {% if original_marriage_certificate == 'NO' and provide_certificate_later == 'NO'%}
     <div class="review-well clearfix">
         <div class="collapse-trigger collapsed review-well-small" data-toggle="collapse"
         aria-expanded="false" data-target="#collapseF30NMC"

--- a/edivorce/apps/core/utils/efiling_documents.py
+++ b/edivorce/apps/core/utils/efiling_documents.py
@@ -30,7 +30,7 @@ def forms_to_file(responses_dict, initial=False):
             uploaded.append({'doc_type': 'AFF', 'party_code': 0})
             uploaded.append({'doc_type': 'EFSS0', 'party_code': 0})
 
-        if provide_certificate_later and responses_dict.get('marriage_certificate_in_english') == 'NO':
+        if responses_dict.get('marriage_certificate_in_english') == 'NO':
             uploaded.append({'doc_type': 'AFTL', 'party_code': 0})
             uploaded.append({'doc_type': 'EFSS1', 'party_code': 1})
 


### PR DESCRIPTION
Fixed the failing test on Certificate of Translation by removing the condition for a saying that you will provide a Marriage Certificate later. They should submit a Certificate of Translation any time they say that their Marriage Certificate is not in english.

Also, clarified some conditionals to include that they will not provide an original Marriage Certificate.