### PR TITLE
When not asking for child orders, don't show calculated values

### DIFF
--- a/edivorce/apps/core/templates/pdf/partials/fact_sheet_b.html
+++ b/edivorce/apps/core/templates/pdf/partials/fact_sheet_b.html
@@ -73,8 +73,12 @@
 
   <p>
     It is proposed that child support in the amount of
-    {{ derived.total_monthly_b|money }}
-    per month be paid by {{ derived.child_support_payor }}.
+    {% if derived.wants_child_support and responses.child_support_in_order != 'NO' %}
+      {{ derived.total_monthly_b|money }} per month be paid by {{ derived.child_support_payor }}.
+    {% else %}
+      _________ per month be paid by ______________________.
+    {% endif %}
+
   </p>
 
 </div>


### PR DESCRIPTION
More details are available in https://tickets.oxd.com/browse/DIV-1485

When the user does not ask for orders pertaining to children (either via Step 1: What are you asking for? or Step 6: What are you asking for?) the system should not display the amount owed and the payor in Form 37, Fact Sheet B, instead showing blanks.