### PR TITLE
Disable debug mode on dev due to sass error

### DIFF
--- a/edivorce/settings/openshift.py
+++ b/edivorce/settings/openshift.py
@@ -56,7 +56,7 @@ EFILING_ENABLED_GLOBALLY = False
 EFILING_HUB_ENABLED = True
 
 if DEPLOYMENT_TYPE == 'dev':
-    DEBUG = True
+    # DEBUG = True  ## dev should be in debug mode, but it causes an error with django-sass-processor
     CSRF_COOKIE_AGE = None
     SESSION_COOKIE_AGE = 3600
     REGISTER_BCEID_URL = 'https://www.test.bceid.ca/directories/bluepages/details.aspx?serviceID=5522'


### PR DESCRIPTION
The error on dev.justice.gov.bc.ca/divorce was only happening in debug mode, so this PR disables debug mode on dev.

test was using the same docker image and had no errors.  