### PR TITLE
DIV-16: Refactor link checker

### DIFF
--- a/edivorce/apps/core/management/commands/link_check.py
+++ b/edivorce/apps/core/management/commands/link_check.py
@@ -28,6 +28,8 @@ class Command(BaseCommand):
             print(f'Checking link: {address}')
             response = session.get(address, headers=self.HEADERS, timeout=15)
             response.raise_for_status()
+        except requests.exceptions.Timeout:
+            return None  # Ignore timeouts
         except requests.exceptions.RequestException as e:
             return str(e)
         return None


### PR DESCRIPTION
Currently the link checker will throw errors such as:

```
File: /home/runner/work/eDivorce/eDivorce/edivorce/apps/core/templates/incomplete.html
link: https://www2.gov.bc.ca/gov/content/justice/courthouse-services/documents-forms-records/court-forms/sup-family-forms?keyword=supreme&keyword=court&keyword=divorce&keyword=forms
Error: Remote end closed connection without response
```

The link does work in a browser.

This PR is to refactor the link checker:

- Use the requests library instead, with a common session, browser-like headers and timeout
- Avoid checking the same link multiple times
- Omit localhost links from being checked

This reduces the number of errors:

```
Errors found:

-------------------------------------------------------------
File: /Users/dylanrogowsky/Documents/Git/eDivorce/edivorce/apps/core/templates/legal.html
Link: http://lawcourtscenter.camp7.org/page-1770376
Error: 404 Client Error: Not found for url: http://lawcourtscenter.camp7.org/page-1770376
-------------------------------------------------------------
File: /Users/dylanrogowsky/Documents/Git/eDivorce/edivorce/apps/core/templates/question/01_orders.html
Link: https://www2.gov.bc.ca/gov/content/justice/about-bcs-justice-system/legislation-policy/legislation-updates/family-law-act
Error: 404 Client Error: Not Found for url: https://www2.gov.bc.ca/gov/content/justice/about-bcs-justice-system/legislation-policy/legislation-updates/family-law-act
```

There are valid broken links for:

- http://lawcourtscenter.camp7.org/page-1770376
- https://www2.gov.bc.ca/gov/content/justice/about-bcs-justice-system/legislation-policy/legislation-updates/family-law-act