### PR TITLE
DIV-23: Form 37 and 38 changes

### DIFF
--- a/edivorce/apps/core/static/css/weasyprint.css
+++ b/edivorce/apps/core/static/css/weasyprint.css
@@ -215,6 +215,16 @@ ol.numbered-paragraphs li {
   width: 6%;
 }
 
+.notary-signature td.collapse-width {
+  width: 1%;
+  white-space: nowrap;
+}
+
+.notary-signature td.notary-line-text {
+  font-size: 0.88em;
+  padding-bottom: 8px;
+}
+
 .new-paragraph {
   margin-top: 0.5em;
 }

--- a/edivorce/apps/core/templates/pdf/form37.html
+++ b/edivorce/apps/core/templates/pdf/form37.html
@@ -45,7 +45,7 @@
             {% required responses|name_spouse %}
 {% endif %}
             in this case,<br>
-            and was made on <span class="form-entry-md not-complete form-underline"></span>
+            and was made on {% now "F jS, Y" %}
         </p>
 
         <h3 class="text-center">

--- a/edivorce/apps/core/templates/pdf/form38.html
+++ b/edivorce/apps/core/templates/pdf/form38.html
@@ -44,7 +44,7 @@
             {% required responses|name_spouse %}
 {% endif %}
             in this case,<br>
-            and was made on <span class="form-entry-md not-complete form-underline"></span>
+            and was made on {% now "F jS, Y" %}
         </p>
 
         <p class="text-center">

--- a/edivorce/apps/core/templates/pdf/partials/notary_signature.html
+++ b/edivorce/apps/core/templates/pdf/partials/notary_signature.html
@@ -1,51 +1,63 @@
 <table class="notary-signature">
   <tbody>
     <tr>
-      <td class=""> SWORN (OR AFFIRMED) BEFORE ME</td>
+      <td class="" colspan="2">SWORN (OR AFFIRMED) BEFORE ME</td>
       <td class="parens"> ) </td>
       <td class=""> </td>
     </tr>
     <tr>
-      <td class="">at <span class="form-entry not-complete">&nbsp;</span></td>
+      <td class="collapse-width">at </td>
+      <td class="form-underline">&nbsp;</td>
       <td class="parens"> ) </td>
       <td class=""></td>
     </tr>
     <tr>
-      <td class="">on</td>
+      <td class="collapse-width"></td>
+      <td class="notary-line-text">[commissioner’s city/town]</td>
       <td class="parens"> ) </td>
       <td class=""></td>
     </tr>
     <tr>
-      <td class=""></td>
+      <td class="collapse-width">on </td>
+      <td class="form-underline">&nbsp;</td>
       <td class="parens"> ) </td>
       <td class=""></td>
     </tr>
     <tr>
-      <td class=""></td>
+      <td class="collapse-width"></td>
+      <td class="notary-line-text">[date]</td>
       <td class="parens"> ) </td>
       <td class=""></td>
     </tr>
     <tr>
-      <td class=""></td>
+      <td class="" colspan="2"></td>
       <td class="parens"> ) </td>
       <td class=""></td>
     </tr>
     <tr>
-      <td class=""></td>
+      <td class="" colspan="2"></td>
       <td class="parens"> ) </td>
       <td class=""></td>
     </tr>
     <tr>
-      <td class="signature-above">A commissioner for taking</td>
+      <td class="" colspan="2"></td>
+      <td class="parens"> ) </td>
+      <td class=""></td>
+    </tr>
+    <tr>
+      <td class="" colspan="2"></td>
+      <td class="parens"> ) </td>
+      <td class=""></td>
+    </tr>
+    <tr>
+      <td class="signature-above" colspan="2">A commissioner for taking</td>
       <td class="parens"> ) </td>
       <td class="signature-above">{{ name|upper }}</td>
     </tr>
     <tr>
-      <td class="">affidavits for British Columbia</td>
+      <td class="" colspan="2">affidavits for British Columbia</td>
       <td class="parens"> ) </td>
       <td class=""></td>
     </tr>
   </tbody>
 </table>
-
-


### PR DESCRIPTION
Changes are to Form 37 and 38:

- On the first page in the top right, populate the date (now) when the form was generated
- On the notary signature block, include a line and hint text under

<img width="804" alt="image" src="https://github.com/user-attachments/assets/7e716d96-7bec-4b9d-9860-cb6b72891501">
